### PR TITLE
Closing polygons in dg_process_polydata

### DIFF
--- a/R/dggridR.R
+++ b/R/dggridR.R
@@ -558,7 +558,10 @@ dg_process_polydata <- function(polydata,frame,wrapcells){
   polydata  <- as.data.frame(polydata)
   polydata  <- split(polydata, polydata$seqnum)
   an        <- names(polydata)
-  polydata  <- lapply(polydata, function(x) { x["seqnum"] <- NULL; x })
+  polydata  <- lapply(polydata, function(x) {
+    x["seqnum"] <- NULL
+    x <- rbind(x, x[1,])
+    x })
   polydata  <- lapply(polydata, Polygon)
   polydata  <- lapply(seq_along(polydata), function(i) Polygons(list(polydata[[i]]), ID = an[i]  ))
   polydata  <- SpatialPolygons(polydata, proj4string = CRS("+proj=longlat +datum=WGS84") )


### PR DESCRIPTION
The first and last row of the dataframe going into the Polygon-function in dggridR.R, line 565 should have the same coordinates. 
The function works but it outputs annoying warnings when working with triangles. 
E.g.
```
dggs <- dggridR::dgconstruct(spacing=250, metric=TRUE, precision=10,resround='nearest', topology = "TRIANGLE", aperture = 4)
grid <- dggridR::dgrectgrid(dggs, 55, 10, 59, 17)
```
This pull request fixes that. 