### PR TITLE
Fix dgGEO_to_SEQNUM argument order in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ dggs          <- dgconstruct(spacing=1000, metric=FALSE, resround='down')
 data(dgquakes)
 
 #Get the corresponding grid cells for each earthquake epicenter (lat-long pair)
-dgquakes$cell <- dgGEO_to_SEQNUM(dggs, dgquakes$lat, dgquakes$lon)$seqnum
+dgquakes$cell <- dgGEO_to_SEQNUM(dggs, dgquakes$lon, dgquakes$lat)$seqnum
 
 #Get the number of earthquakes in each equally-sized cell
 quakecounts   <- dgquakes %>% group_by(cell) %>% summarise(count=n())


### PR DESCRIPTION
This fixes the argument order of `dgGEO_to_SEQNUM()` in the README from lat/lon to lon/lat.