### PR TITLE
might help fix valgrind issue in #42

### DIFF
--- a/vignettes/dggridR.Rmd
+++ b/vignettes/dggridR.Rmd
@@ -20,7 +20,7 @@ library(ggplot2)
 # Generate grids of various sizes
 hgrids <- lapply(3:5, function(res) dgconstruct(res=res))
 hgrids <- lapply(hgrids, function(dggs) dgearthgrid(dggs))
-hgrids <- lapply(hgrids, function(x) st_wrap_dateline(x, options = c("WRAPDATELINE=YES","DATELINEOFFSET=180"), quiet = TRUE))
+hgrids <- lapply(hgrids, function(x) st_wrap_dateline(x, options = c("WRAPDATELINE=YES","DATELINEOFFSET=10"), quiet = TRUE))
 
 countries <- map_data("world")
 

--- a/vignettes/dggridR.Rmd
+++ b/vignettes/dggridR.Rmd
@@ -26,11 +26,11 @@ countries <- map_data("world")
 
 # Crop generate dgrids to areas of interest
 bounds = st_bbox(c(xmin = -90, xmax = 75, ymin = -90, ymax = 90), crs = st_crs(4326))
-hgrids[[1]] = hgrids[[1]] %>% st_filter(st_as_sfc(bounds), .predicate=st_within)
+hgrids[[1]] = hgrids[[1]] %>% st_make_valid() %>% st_filter(st_as_sfc(bounds), .predicate=st_within)
 bounds = st_bbox(c(xmin = 20, xmax = 145, ymin = -90, ymax = 90), crs = st_crs(4326))
-hgrids[[2]] = hgrids[[2]] %>% st_filter(st_as_sfc(bounds), .predicate=st_within)
+hgrids[[2]] = hgrids[[2]] %>% st_make_valid() %>% st_filter(st_as_sfc(bounds), .predicate=st_within)
 bounds = st_bbox(c(xmin = 90, xmax = 215, ymin = -90, ymax = 90), crs = st_crs(4326))
-hgrids[[3]] = hgrids[[3]] %>% st_filter(st_as_sfc(bounds), .predicate=st_within)
+hgrids[[3]] = hgrids[[3]] %>% st_make_valid() %>% st_filter(st_as_sfc(bounds), .predicate=st_within)
 
 ggplot() +
     geom_polygon(data=countries,  aes(x=long, y=lat, group=group), fill=NA, color="black")   +


### PR DESCRIPTION
This removes the GDAL wrap_dateline message, but not the error in dggridR.Rmd happening under valgrind